### PR TITLE
Consolidate JWT logic and added middleware for protected routes

### DIFF
--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import bcrypt from "bcrypt";
+import { signJwt } from "@/lib/auth";
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const { email, password } = body;
+
+    if (!email || !password) {
+      return NextResponse.json({ error: "Missing email or password" }, { status: 400 });
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    }
+
+    const passwordMatch = await bcrypt.compare(password, user.password);
+
+    if (!passwordMatch) {
+      return NextResponse.json({ error: "Invalid credentials" }, { status: 401 });
+    }
+
+    const token = signJwt({ id: user.id, email: user.email });
+
+    return NextResponse.json({ message: "Login successful", token }, { status: 200 });
+  } catch (error) {
+    console.error("[LOGIN_ERROR]", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/app/api/protected/route.ts
+++ b/src/app/api/protected/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth";
+
+export const GET = withAuth(async (req, user) => {
+  return NextResponse.json({
+    message: "Access granted",
+    user,
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
 import jwt from "jsonwebtoken";
 
 const JWT_SECRET = process.env.JWT_SECRET || "dev-secret";
+
+// ----- JWT Utilities -----
 
 export function signJwt(payload: object): string {
   return jwt.sign(payload, JWT_SECRET, { expiresIn: "7d" });
@@ -12,4 +15,25 @@ export function verifyJwt<T>(token: string): T | null {
   } catch {
     return null;
   }
+}
+
+// ----- Middleware for Protected Routes -----
+
+export function withAuth(handler: (req: NextRequest, user: any) => Promise<NextResponse>) {
+  return async function (req: NextRequest) {
+    const authHeader = req.headers.get("authorization");
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return NextResponse.json({ error: "Missing or invalid authorization header" }, { status: 401 });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const user = verifyJwt(token);
+
+    if (!user) {
+      return NextResponse.json({ error: "Invalid or expired token" }, { status: 401 });
+    }
+
+    return handler(req, user);
+  };
 }


### PR DESCRIPTION
# /api/login route with token returned
![image](https://github.com/user-attachments/assets/bbcd8d49-077e-4980-9add-062e03c83aba)

# /api/protected route demonstration. Pass "Bearer 'token'" into the headers 
![image](https://github.com/user-attachments/assets/e13b0075-5be4-4500-b7ab-100ea34903d5)
