### PR TITLE
fix(address): Resolve default address editing and unique constraint i…

### DIFF
--- a/prisma/migrations/20250621063352_fix_address_unique_constraint/migration.sql
+++ b/prisma/migrations/20250621063352_fix_address_unique_constraint/migration.sql
@@ -1,0 +1,2 @@
+-- DropIndex
+DROP INDEX "Address_userId_isDefault_key";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,8 +61,8 @@ model Address {
   // Relationship to Order (An address can be used for multiple orders as a shipping address)
   orders     Order[]   // Orders that used this address as shipping address
 
-  // Ensures only one default address per user. 'isDefault' must be true for this uniqueness constraint to apply.
-  @@unique([userId, isDefault], name: "UserDefaultAddress")
+  // It correctly allows multiple non-default addresses (isDefault: false) for the same user.
+ // @@unique([userId, isDefault], name: "UserDefaultAddress", where: { isDefault: true })
 }
 
 // New: Cart Model


### PR DESCRIPTION
…ssue

This commit addresses the issue preventing correct editing and management of default addresses.

Key changes:
- **Prisma Schema ():** Removed the problematic  constraint from the  model.
- **Backend Logic (API routes):** Now solely relies on the application-level logic within  and  to ensure only one default address per user. This unblocks the  operations that were failing due to the database constraint.
- **Frontend Functionality:** Address editing (specifically changing the  status) should now work as expected on the dashboard.