### PR TITLE
feat(cart): add delivery type and address selection to CartSheet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-navigation-menu": "^1.2.13",
+        "@radix-ui/react-radio-group": "^1.3.7",
         "@radix-ui/react-scroll-area": "^1.2.9",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
@@ -1475,6 +1476,67 @@
       "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.7.tgz",
+      "integrity": "sha512-9w5XhD0KPOrm92OTTE0SysH3sYzHsSTHNvZgUBo/VZ80VdYyB5RneDbc0dKpURS24IxkoFRu/hI0i4XyfFwY6g==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-navigation-menu": "^1.2.13",
+    "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-scroll-area": "^1.2.9",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",

--- a/src/app/api/checkout/route.ts
+++ b/src/app/api/checkout/route.ts
@@ -17,6 +17,8 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "No cart items provided" }, { status: 400 });
   }
 
+  const deliveryTypeEnum = deliveryType === "DELIVERY" ? "DELIVERY" : "PICKUP";
+
   // Compute subtotal and tax
   const subtotalAmount = cartItems.reduce(
     (sum: number, item: any) => sum + item.product.price * item.quantity,
@@ -32,8 +34,8 @@ export async function POST(req: NextRequest) {
       subtotalAmount,
       taxAmount,
       totalAmount,
-      deliveryType: "PICKUP",
-      shippingAddressId,
+      deliveryType: deliveryTypeEnum,
+      shippingAddressId: deliveryTypeEnum === "DELIVERY" ? shippingAddressId : null,
       status: "PENDING",
       orderItems: {
         create: cartItems.map((item: any) => ({
@@ -68,10 +70,10 @@ export async function POST(req: NextRequest) {
     success_url: `${baseUrl}/dashboard`,
     cancel_url: `${baseUrl}/cancel`,
     payment_intent_data: {
-      // Here we send the orderId in metadata 
-      // Stripe webhook will use this to update the order
       metadata: {
         orderId: newOrder.id,
+        deliveryType: deliveryTypeEnum,
+        shippingAddressId: deliveryTypeEnum === "DELIVERY" ? shippingAddressId || "" : "",
       },
     },
   });

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/hooks/useAddresses.ts
+++ b/src/hooks/useAddresses.ts
@@ -106,7 +106,7 @@ export function useAddresses(): UseAddressesReturn {
         throw new Error(errorData.error || `Failed to delete address: ${res.status}`);
       }
 
-      console.log(`Address ${addressToDeleteId} deleted successfully.`);
+      //console.log(`Address ${addressToDeleteId} deleted successfully.`);
       fetchAddresses(); // Re-fetch addresses to update the list
       setIsDeleteDialogOpen(false); // Close dialog
       setAddressToDeleteId(null); // Clear ID


### PR DESCRIPTION
- Integrated delivery option selection (PICKUP or DELIVERY) directly in the CartSheet
- Conditionally display user’s saved addresses if DELIVERY is selected
- Hooked into useAddresses to fetch and display saved addresses
- Added fallback and error messaging for empty or failed address loads
- Implemented onOpenChange on Sheet to re-fetch addresses when CartSheet opens
- Persist deliveryType and selected shippingAddressId in the Stripe checkout metadata
- Ensured stale addresses are not shown by re-fetching every time CartSheet is opened

This change lays the foundation for handling delivery logic during checkout, ensuring users can choose between pickup or delivery and providing valid shipping information where required.